### PR TITLE
Back to single screen

### DIFF
--- a/app/components/fields/NumericInput/NumericInput.js
+++ b/app/components/fields/NumericInput/NumericInput.js
@@ -4,15 +4,14 @@ import { StyleSheet, Text, TextInput, View } from 'react-native';
 
 import colors from '../../../config/colors';
 
-const NumericInput = ({ inputKey, saveRef, nextInput, focusNext, unit, unitStyle, style, ...props }) => (
+const NumericInput = ({ unit, unitStyle, style, registerInput, ...props }) => (
   <View style={styles.wrapper}>
     <TextInput
       selectTextOnFocus
-      underlineColorAndroid="transparent"
       keyboardType="numeric"
+      underlineColorAndroid="transparent"
+      ref={(input) => registerInput && registerInput(input)}
       style={[styles.input, style, props.editable === false && styles.disabled]} // eslint-disable-line
-      ref={(input) => saveRef && saveRef(inputKey, input)}
-      onSubmitEditing={() => focusNext && focusNext(nextInput)}
       {...props}
     />
     <Text style={unitStyle}>{unit}</Text>
@@ -20,17 +19,13 @@ const NumericInput = ({ inputKey, saveRef, nextInput, focusNext, unit, unitStyle
 );
 
 NumericInput.propTypes = {
-  focusNext: PropTypes.func,
-  inputKey: PropTypes.string,
-  nextInput: PropTypes.string,
-  saveRef: PropTypes.func,
   style: TextInput.propTypes.style,
   unit: PropTypes.string.isRequired,
   unitStyle: Text.propTypes.style,
+  registerInput: PropTypes.func,
 };
 
 NumericInput.defaultProps = {
-  defaultValue: '0',
   unitStyle: null,
 };
 

--- a/app/components/fields/NumericInput/__snapshots__/NumericInput.test.js.snap
+++ b/app/components/fields/NumericInput/__snapshots__/NumericInput.test.js.snap
@@ -12,9 +12,7 @@ exports[`render correctly 1`] = `
 >
   <TextInput
     allowFontScaling={true}
-    defaultValue="0"
     keyboardType="numeric"
-    onSubmitEditing={[Function]}
     selectTextOnFocus={true}
     style={
       Array [

--- a/app/components/layout/Col.js
+++ b/app/components/layout/Col.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { View } from 'react-native';
+import { View, ViewPropTypes } from 'react-native';
 
 const Col = ({ size, style, children, ...props }) => {
   const styles = [
@@ -20,7 +20,7 @@ const Col = ({ size, style, children, ...props }) => {
 
 Col.propTypes = {
   size: PropTypes.number.isRequired,
-  style: View.propTypes.style,
+  style: ViewPropTypes.style,
   children: PropTypes.node,
 };
 

--- a/app/components/layout/Label.js
+++ b/app/components/layout/Label.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Text, StyleSheet, View } from 'react-native';
+import { Text, StyleSheet, View, ViewPropTypes } from 'react-native';
 
 import colors from '../../config/colors';
 
@@ -22,9 +22,9 @@ const Label = ({ text, textStyle, wrapperStyle, lineStyle, toUpperCase, shadow }
 
 Label.propTypes = {
   text: PropTypes.string.isRequired,
-  wrapperStyle: View.propTypes.style,
+  wrapperStyle: ViewPropTypes.style,
   textStyle: Text.propTypes.style,
-  lineStyle: View.propTypes.style,
+  lineStyle: ViewPropTypes.style,
   toUpperCase: PropTypes.bool,
   shadow: PropTypes.bool,
 };

--- a/app/components/layout/Row.js
+++ b/app/components/layout/Row.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { View } from 'react-native';
+import { View, ViewPropTypes } from 'react-native';
 
 const Row = ({ size, style, children, ...props }) => {
   const styles = [
@@ -20,7 +20,7 @@ const Row = ({ size, style, children, ...props }) => {
 
 Row.propTypes = {
   size: PropTypes.number.isRequired,
-  style: View.propTypes.style,
+  style: ViewPropTypes.style,
   children: PropTypes.node,
 };
 

--- a/app/data/isotopes.js
+++ b/app/data/isotopes.js
@@ -1,13 +1,13 @@
 const isotopes = {
-  'technetium-99m': {
-    name: 'Technetium 99m',
-    halfLife: 6.01,
-    lambda: 0.1153,
-  },
   'iodine-131': {
     name: 'Iodine 131',
     halfLife: 192.48,
     lambda: 0.0036,
+  },
+  'technetium-99m': {
+    name: 'Technetium 99m',
+    halfLife: 6.01,
+    lambda: 0.1153,
   },
 };
 

--- a/app/index.js
+++ b/app/index.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import { StatusBar, StyleSheet, Text } from 'react-native';
+import { StatusBar, StyleSheet } from 'react-native';
 import { StackNavigator } from 'react-navigation';
 
 import colors from './config/colors';

--- a/app/lib/calculators/volume.js
+++ b/app/lib/calculators/volume.js
@@ -1,4 +1,5 @@
 import { DateTime } from 'luxon';
+import isotopes from '../../data/isotopes';
 
 /**
  * Calculate the hours difference between two dates
@@ -39,8 +40,9 @@ export default function volumeCalculator({
   initialVolume,
   isotope,
 }) {
+
   const calculationDate = new Date(Date.now());
-  const lambda = isotope.lambda;
+  const lambda = isotopes[isotope].lambda;
   const differenceInHours = hoursDifference(calibrationDate, calculationDate);
   const currentActivity = initialActivity * Math.exp(-lambda * differenceInHours);
   const vialConcentration = currentActivity / initialVolume;
@@ -48,8 +50,8 @@ export default function volumeCalculator({
 
   return {
     calculationDate,
-    currentActivity,
-    vialConcentration,
     neededVolume,
+    currentActivity: Number(currentActivity).toFixed(1),
+    vialConcentration: Number(vialConcentration).toFixed(1),
   };
 }

--- a/app/lib/calculators/volume.test.js
+++ b/app/lib/calculators/volume.test.js
@@ -6,7 +6,7 @@ import volumeCalculator from './volume';
 describe('volumeCalculator', () => {
   const Tc99m = isotopes['technetium-99m'];
   const params = {
-    isotope: Tc99m,
+    isotope: 'technetium-99m',
     calibrationDate: DateTime.local(),
     initialVolume: 10,
     initialActivity: 1450,
@@ -38,7 +38,7 @@ describe('volumeCalculator', () => {
     describe('calibrated right now', () => {
       test('returns 2.1 ml of needed volume for 300 mCi desired activity', () => {
         const result = volumeCalculator({
-          isotope: Tc99m,
+          isotope: 'technetium-99m',
           calibrationDate: now,
           initialActivity: 1450,
           initialVolume: 10,
@@ -52,7 +52,7 @@ describe('volumeCalculator', () => {
     describe('calibrated 3 hours ago', () => {
       test('returns 2.9 ml volume needed for 300 mCi desired activity', () => {
         const result = volumeCalculator({
-          isotope: Tc99m,
+          isotope: 'technetium-99m',
           calibrationDate: now.minus({ hours: 3 }),
           initialActivity: 1450,
           initialVolume: 10,
@@ -66,7 +66,7 @@ describe('volumeCalculator', () => {
     describe('calibrated one half life (6.01h) ago', () => {
       test('returns 10 ml volume needed for 725 mCi desired activity', () => {
         const result = volumeCalculator({
-          isotope: Tc99m,
+          isotope: 'technetium-99m',
           calibrationDate: now.minus({ hours: Tc99m.halfLife }),
           initialActivity: 1450,
           initialVolume: 10,
@@ -80,7 +80,7 @@ describe('volumeCalculator', () => {
     describe('calibrated one half life (6.01h) in the future', () => {
       test('returns 1 ml volume needed for 300 mCi desired activity', () => {
         const result = volumeCalculator({
-          isotope: Tc99m,
+          isotope: 'technetium-99m',
           calibrationDate: now.plus({ hours: Tc99m.halfLife }),
           initialActivity: 1450,
           initialVolume: 10,

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -1,0 +1,11 @@
+import { DateTime } from 'luxon';
+
+const formatDate = (date, format = DateTime.DATETIME_SHORT) => {
+  const dt = date instanceof DateTime ? date : DateTime.fromJSDate(date);
+
+  return dt.toLocaleString(format);
+};
+
+export {
+  formatDate,
+};

--- a/app/screens/VolumeCalculator.js
+++ b/app/screens/VolumeCalculator.js
@@ -1,25 +1,147 @@
 import React, { Fragment } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, TouchableNativeFeedback, View } from 'react-native';
+import { DateTime } from 'luxon';
 
-import BaseCalculator from './BaseCalculator';
+import calculateVolume from '../lib/calculators/volume';
 import { Row, Column, Label } from '../components/layout';
-import { NumericInput } from '../components/fields';
+import { DateTimeInput, IsotopePicker, NumericInput } from '../components/fields';
+
 import colors from '../config/colors';
+import { formatDate } from '../lib/utils';
 
-class VolumeCalculator extends BaseCalculator {
+class VolumeCalculator extends React.Component {
 
-  fields() {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isotope: 'technetium-99m',
+      calibrationDate: DateTime.local().toJSDate(),
+      initialActivity: 0,
+      initialVolume: 0,
+      desiredActivity: 0,
+      neededVolume: 0,
+      currentActivity: 0,
+      vialConcentration: 0,
+      lessVolumeThanNeeded: false,
+    };
+
+    this.registeredInputs = {};
+
+    // binding
+    this.registerInput = this.registerInput.bind(this);
+    this.setFocus = this.setFocus.bind(this);
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    // Only re-render if there are new values
+    return [
+      'neededVolume',
+      'currentActivity',
+      'vialConcentration',
+    ].some((prop) => this.state[prop] !== nextState[prop]);
+  }
+
+  /**
+   * Stores a input reference
+   *
+   * @params {string|number} id - input identifier
+   * @params {*} ref - TextInput reference
+   */
+  registerInput(id, ref) {
+    this.registeredInputs[id] = ref;
+  }
+
+  /**
+   * Set focus to input for given identifier
+   *
+   * @params {string|number} id - input identifier
+   */
+  setFocus(id) {
+    this.registeredInputs[id].focus();
+  }
+
+
+  // FIXME: only do calculation if something changed
+  handleChange(data) {
+    const result = calculateVolume({ ...this.state, ...data });
+    const lessVolumeThanNeeded = this.state.initialVolume < result.neededVolume;
+
+    this.setState({ ...data, ...result, lessVolumeThanNeeded });
+  }
+
+  renderWarning() {
+    if (this.state.lessVolumeThanNeeded) {
+      return (
+        <View>
+          <Text style={styles.warningEmoji}>{'\u26A0\uFE0F'}</Text>
+          <Text style={styles.warning}>There is less volume than needed</Text>
+        </View>
+      );
+    }
+
+    return null;
+  }
+
+  renderInformation() {
+    if (this.state.calculationDate) {
+      return (
+        <TouchableNativeFeedback
+          background={TouchableNativeFeedback.Ripple(colors.materialBlueGray500)}
+          borderless={true}
+        >
+          <View>
+            <Text style={styles.info}>
+              Calculated at {formatDate(this.state.calculationDate)}
+            </Text>
+          </View>
+        </TouchableNativeFeedback>
+      );
+    }
+
+    return null;
+  }
+
+  render() {
     return (
-      <Fragment>
+      <View style={styles.wrapper}>
+        <Row size={0.3} />
+
+        <Row>
+          <Column>
+            <Label text="Isotope" />
+            <IsotopePicker
+              isotope={this.state.isotope}
+              onValueChange={(isotope) => this.handleChange({ isotope })}
+            />
+          </Column>
+        </Row>
+
+        <Row>
+          <Column>
+            <Label text="Calibration Date" />
+            <DateTimeInput
+              date={this.state.calibrationDate}
+              onChange={(calibrationDate) => this.handleChange({ calibrationDate })}
+            />
+          </Column>
+        </Row>
+
+        <Row size={0.2} />
+
         <Row size={2}>
           <Column style={styles.columnLeft}>
             <Label text="Initial activity" />
             <NumericInput
               unit="mCi"
-              inputKey="initialActivity"
-              nextInput="initialVolume"
-              focusNext={this.focusInput}
-              saveRef={this.saveInputRef}
+              returnKeyType="next"
+              defaultValue={`${this.state.initialActivity}`}
+              registerInput={(input) => this.registerInput('initialActivity', input)}
+              onEndEditing={(event) => {
+                this.handleChange({ initialActivity: event.nativeEvent.text });
+                this.setFocus('initialVolume');
+              }}
             />
           </Column>
 
@@ -27,15 +149,15 @@ class VolumeCalculator extends BaseCalculator {
             <Label text="Initial volume" />
             <NumericInput
               unit="mL"
-              inputKey="initialVolume"
-              nextInput="desiredActivity"
-              focusNext={this.focusInput}
-              saveRef={this.saveInputRef}
+              returnKeyType="next"
+              defaultValue={`${this.state.initialVolume}`}
+              registerInput={(input) => this.registerInput('initialVolume', input)}
+              onEndEditing={(event) => {
+                this.handleChange({ initialVolume: event.nativeEvent.text });
+                this.setFocus('desiredActivity');
+              }}
             />
-            <View>
-              <Text style={styles.warningEmoji}>{'\u26A0\uFE0F'}</Text>
-              <Text style={styles.warning}>There is less volume than needed</Text>
-            </View>
+            { this.renderWarning() }
           </Column>
         </Row>
 
@@ -44,8 +166,11 @@ class VolumeCalculator extends BaseCalculator {
             <Label text="Desired activity" />
             <NumericInput
               unit="mCi"
-              inputKey="desiredActivity"
-              saveRef={this.saveInputRef}
+              defaultValue={`${this.state.desiredActivity}`}
+              registerInput={(input) => this.registerInput('desiredActivity', input)}
+              onEndEditing={(event) => {
+                this.handleChange({ desiredActivity: event.nativeEvent.text });
+              }}
             />
           </Column>
 
@@ -54,6 +179,7 @@ class VolumeCalculator extends BaseCalculator {
             <NumericInput
               unit="mL"
               editable={false}
+              defaultValue={`${this.state.neededVolume}`}
             />
           </Column>
         </Row>
@@ -66,26 +192,51 @@ class VolumeCalculator extends BaseCalculator {
               editable={false}
               style={styles.smallNumber}
               unitStyle={styles.smallUnit}
+              defaultValue={`${this.state.currentActivity}`}
             />
           </Column>
 
           <Column>
             <Label text="Vial concentration" />
             <NumericInput
-              unit="mL"
+              unit="mCi/mL"
               editable={false}
               style={styles.smallNumber}
               unitStyle={styles.smallUnit}
+              defaultValue={`${this.state.vialConcentration}`}
             />
           </Column>
         </Row>
-      </Fragment>
+
+        <Row size={1}>
+          <Column>
+            <Label
+              shadow={false}
+              text="·"
+            />
+            { this.renderInformation() }
+          </Column>
+        </Row>
+      </View>
     );
   }
 
 }
 
+VolumeCalculator.defaultProps = {
+  isotope: 'technetium-99m',
+};
+
 const styles = StyleSheet.create({
+  wrapper: {
+    flex: 1,
+    backgroundColor: colors.white,
+  },
+
+  info: {
+    padding: 10,
+    alignSelf: 'center',
+  },
   columnLeft: {
     borderRightColor: colors.materialGray400,
     borderRightWidth: 0.5,

--- a/app/screens/__snapshots__/VolumeCalculator.test.js.snap
+++ b/app/screens/__snapshots__/VolumeCalculator.test.js.snap
@@ -135,21 +135,21 @@ exports[`renders correctly 1`] = `
             items={
               Array [
                 Object {
-                  "label": "Technetium 99m",
-                  "textColor": undefined,
-                  "value": "technetium-99m",
-                },
-                Object {
                   "label": "Iodine 131",
                   "textColor": undefined,
                   "value": "iodine-131",
+                },
+                Object {
+                  "label": "Technetium 99m",
+                  "textColor": undefined,
+                  "value": "technetium-99m",
                 },
               ]
             }
             onChange={[Function]}
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
-            selectedIndex={0}
+            selectedIndex={1}
             style={
               Array [
                 Object {
@@ -350,7 +350,8 @@ exports[`renders correctly 1`] = `
           allowFontScaling={true}
           defaultValue="0"
           keyboardType="numeric"
-          onSubmitEditing={[Function]}
+          onEndEditing={[Function]}
+          returnKeyType="next"
           selectTextOnFocus={true}
           style={
             Array [
@@ -457,7 +458,8 @@ exports[`renders correctly 1`] = `
           allowFontScaling={true}
           defaultValue="0"
           keyboardType="numeric"
-          onSubmitEditing={[Function]}
+          onEndEditing={[Function]}
+          returnKeyType="next"
           selectTextOnFocus={true}
           style={
             Array [
@@ -480,35 +482,6 @@ exports[`renders correctly 1`] = `
           style={null}
         >
           mL
-        </Text>
-      </View>
-      <View>
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-          style={
-            Object {
-              "alignSelf": "center",
-              "fontSize": 15,
-            }
-          }
-        >
-          ⚠️
-        </Text>
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-          style={
-            Object {
-              "alignSelf": "center",
-              "color": "#FF5722",
-              "fontSize": 10,
-            }
-          }
-        >
-          There is less volume than needed
         </Text>
       </View>
     </View>
@@ -608,7 +581,7 @@ exports[`renders correctly 1`] = `
           allowFontScaling={true}
           defaultValue="0"
           keyboardType="numeric"
-          onSubmitEditing={[Function]}
+          onEndEditing={[Function]}
           selectTextOnFocus={true}
           style={
             Array [
@@ -716,7 +689,6 @@ exports[`renders correctly 1`] = `
           defaultValue="0"
           editable={false}
           keyboardType="numeric"
-          onSubmitEditing={[Function]}
           selectTextOnFocus={true}
           style={
             Array [
@@ -841,7 +813,6 @@ exports[`renders correctly 1`] = `
           defaultValue="0"
           editable={false}
           keyboardType="numeric"
-          onSubmitEditing={[Function]}
           selectTextOnFocus={true}
           style={
             Array [
@@ -958,7 +929,6 @@ exports[`renders correctly 1`] = `
           defaultValue="0"
           editable={false}
           keyboardType="numeric"
-          onSubmitEditing={[Function]}
           selectTextOnFocus={true}
           style={
             Array [
@@ -989,7 +959,7 @@ exports[`renders correctly 1`] = `
             }
           }
         >
-          mL
+          mCi/mL
         </Text>
       </View>
     </View>
@@ -1063,19 +1033,6 @@ exports[`renders correctly 1`] = `
           ·
         </Text>
       </View>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Object {
-            "alignSelf": "center",
-            "padding": 10,
-          }
-        }
-      >
-        Information about the calculation
-      </Text>
     </View>
   </View>
 </View>


### PR DESCRIPTION
This commit is a sort of a rollback of 80e3bf53, returning to a single, long, ugly component to have (quickly) an usable prototype by the user that allows to test it and gather information about bugs, UX/UI changes, etc.

Meanwhile, it will be tested some approaches to split the calculator into small parts going back to the initial idea to have the ability to create other calculators screens easily.

